### PR TITLE
Add docker-compose files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 *.wav
 data/spikes/*.json
 *.json
+work/

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  notebook:
+    build: .
+    restart: always
+    ports:
+      - "8888:8888"
+    volumes:
+      - ./work:/home/jovyan/work
+    user: root
+    environment:
+      CHOWN_HOME: "yes"
+      CHOWN_HOME_OPTS: "-R"
+      NB_UID: "${UID}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  notebook:
+    image: dmeliza/comp-neurosci:latest
+    restart: always
+    ports:
+      - "8888:8888"
+    volumes:
+      - ./.:/home/jovyan/work
+    user: root
+    environment:
+      CHOWN_HOME: "yes"
+      CHOWN_HOME_OPTS: "-R"
+      NB_UID: "${UID}"


### PR DESCRIPTION
Hey Dan,

Here are the docker-compose files I made:
- `docker-compose.local.yml` builds the image from source and can be run with `docker-compose -f docker-compose.local.yml up`.
- `docker-compose.yml` pulls from Dockerhub and can be run with `docker-compose up`. This should work even without the rest of the repository being present.

They both rely on the environment variable `UID` to contain the user's UID to allow the unprivileged `jovyan` user in the container to edit files created by the host user on the bind mount. I doubt this is a very portable solution. (Although it wouldn't be too hard to add some instructions to instruct users to set a environment variable that stores their UID, if it's not already present.) I think a better way would be to save the notebooks to a persistent volume, but this has the downside of requiring manual exporting.

I didn't update the README to include instruction because I wanted to hear more about your longer term plan. I think you mentioned running a server with something like JupyterHub. There's definitely a trade-off here between ease of use versus teaching people how to set up their own environment.
